### PR TITLE
修改grpc maxsize 为1G,修改不规范的报名

### DIFF
--- a/server/xchain/xchainServer.go
+++ b/server/xchain/xchainServer.go
@@ -16,7 +16,7 @@ import (
 	logs "github.com/xuperchain/xuper-front/logs"
 	clixchain "github.com/xuperchain/xuper-front/server/client"
 	serv_ca "github.com/xuperchain/xuper-front/service/ca"
-	serv_proxy_xchain "github.com/xuperchain/xuper-front/service/prxyxchain"
+	serv_proxy_xchain "github.com/xuperchain/xuper-front/service/proxyxchain"
 	util_cert "github.com/xuperchain/xuper-front/util/cert"
 	pb "github.com/xuperchain/xuperchain/service/pb"
 	p2p "github.com/xuperchain/xupercore/protos"

--- a/service/proxyxchain/xchainP2pProxy.go
+++ b/service/proxyxchain/xchainP2pProxy.go
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019. Baidu Inc. All Rights Reserved.
  */
-package prxyxchain
+package proxyxchain
 
 import (
 	"context"
@@ -13,6 +13,8 @@ import (
 	p2p "github.com/xuperchain/xupercore/protos"
 	"google.golang.org/grpc"
 )
+
+const MaxRecvMsgSize = 1024 * 1024 * 1024
 
 type XchainP2pProxy struct {
 	host string
@@ -38,13 +40,13 @@ func GetXchainP2pProxy() *XchainP2pProxy {
 				log.Error("XchainP2pProxy.GetXchainP2pProxy: InitCA GenCreds failed", "err", err)
 				return nil
 			}
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds))
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)))
 			if err != nil {
 				log.Error("XchainP2pProxy.GetXchainP2pProxy: InitCA Dial failed", "err", err)
 				return nil
 			}
 		} else {
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure())
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)))
 			if err != nil {
 				log.Error("XchainP2pProxy.GetXchainP2pProxy: Init Dial failed", "err", err)
 				return nil
@@ -69,13 +71,13 @@ func GetXchainP2pProxy() *XchainP2pProxy {
 				xchainProxy.log.Error("XchainP2pProxy.GetXchainP2pProxy: CA failed", "err", err)
 				return nil
 			}
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds))
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)))
 			if err != nil {
 				xchainProxy.log.Error("XchainP2pProxy.GetXchainP2pProxy: CA Dail failed", "err", err)
 				return nil
 			}
 		} else {
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure())
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)))
 			if err != nil {
 				xchainProxy.log.Error("XchainP2pProxy.GetXchainP2pProxy: Dial failed", "err", err)
 				return nil

--- a/service/proxyxchain/xchainP2pProxy.go
+++ b/service/proxyxchain/xchainP2pProxy.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const MaxMessageSize = 1024 * 1024 * 1024
+const maxMessageSize = 1024 * 1024 * 1024
 
 type XchainP2pProxy struct {
 	host string
@@ -40,13 +40,13 @@ func GetXchainP2pProxy() *XchainP2pProxy {
 				log.Error("XchainP2pProxy.GetXchainP2pProxy: InitCA GenCreds failed", "err", err)
 				return nil
 			}
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxMessageSize), grpc.MaxCallSendMsgSize(MaxMessageSize)))
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMessageSize), grpc.MaxCallSendMsgSize(maxMessageSize)))
 			if err != nil {
 				log.Error("XchainP2pProxy.GetXchainP2pProxy: InitCA Dial failed", "err", err)
 				return nil
 			}
 		} else {
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxMessageSize), grpc.MaxCallSendMsgSize(MaxMessageSize)))
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMessageSize), grpc.MaxCallSendMsgSize(maxMessageSize)))
 			if err != nil {
 				log.Error("XchainP2pProxy.GetXchainP2pProxy: Init Dial failed", "err", err)
 				return nil
@@ -71,13 +71,13 @@ func GetXchainP2pProxy() *XchainP2pProxy {
 				xchainProxy.log.Error("XchainP2pProxy.GetXchainP2pProxy: CA failed", "err", err)
 				return nil
 			}
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxMessageSize), grpc.MaxCallSendMsgSize(MaxMessageSize)))
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMessageSize), grpc.MaxCallSendMsgSize(maxMessageSize)))
 			if err != nil {
 				xchainProxy.log.Error("XchainP2pProxy.GetXchainP2pProxy: CA Dail failed", "err", err)
 				return nil
 			}
 		} else {
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxMessageSize), grpc.MaxCallSendMsgSize(MaxMessageSize)))
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMessageSize), grpc.MaxCallSendMsgSize(maxMessageSize)))
 			if err != nil {
 				xchainProxy.log.Error("XchainP2pProxy.GetXchainP2pProxy: Dial failed", "err", err)
 				return nil

--- a/service/proxyxchain/xchainP2pProxy.go
+++ b/service/proxyxchain/xchainP2pProxy.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const MaxRecvMsgSize = 1024 * 1024 * 1024
+const MaxMessageSize = 1024 * 1024 * 1024
 
 type XchainP2pProxy struct {
 	host string
@@ -40,13 +40,13 @@ func GetXchainP2pProxy() *XchainP2pProxy {
 				log.Error("XchainP2pProxy.GetXchainP2pProxy: InitCA GenCreds failed", "err", err)
 				return nil
 			}
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)))
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxMessageSize), grpc.MaxCallSendMsgSize(MaxMessageSize)))
 			if err != nil {
 				log.Error("XchainP2pProxy.GetXchainP2pProxy: InitCA Dial failed", "err", err)
 				return nil
 			}
 		} else {
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)))
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxMessageSize), grpc.MaxCallSendMsgSize(MaxMessageSize)))
 			if err != nil {
 				log.Error("XchainP2pProxy.GetXchainP2pProxy: Init Dial failed", "err", err)
 				return nil
@@ -71,13 +71,13 @@ func GetXchainP2pProxy() *XchainP2pProxy {
 				xchainProxy.log.Error("XchainP2pProxy.GetXchainP2pProxy: CA failed", "err", err)
 				return nil
 			}
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)))
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithTransportCredentials(creds), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxMessageSize), grpc.MaxCallSendMsgSize(MaxMessageSize)))
 			if err != nil {
 				xchainProxy.log.Error("XchainP2pProxy.GetXchainP2pProxy: CA Dail failed", "err", err)
 				return nil
 			}
 		} else {
-			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)))
+			conn, err = grpc.Dial(config.GetXchainServer().Host, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxMessageSize), grpc.MaxCallSendMsgSize(MaxMessageSize)))
 			if err != nil {
 				xchainProxy.log.Error("XchainP2pProxy.GetXchainP2pProxy: Dial failed", "err", err)
 				return nil


### PR DESCRIPTION
## Description

front 代理 xuperchain p2p端口,未设置grpc的maxMessageSize,造成发布合约等操作异常
```lvl=eror msg="SendMessageWithResponse Recv error" module=xchain log_id= s_mod=network call=conn.go:149 pid=351 error="rpc error: code = ResourceExhausted desc = grpc: received message larger than max (6107981 vs. 4194304)" ```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Brief of your solution

```grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMessageSize), grpc.MaxCallSendMsgSize(maxMessageSize))```

## How Has This Been Tested?

xopa共识本地测试通过
